### PR TITLE
Web definitions

### DIFF
--- a/scraping/utilities/definitions/attributes.py
+++ b/scraping/utilities/definitions/attributes.py
@@ -87,6 +87,13 @@ filedates_web = "filedates"
 #TODO: web definitions
 orphan_status = "orphan_status"
 authorisation_row = "authorisation_row"
+overwrite_ec_files = "overwrite_ec_files"
 other_ema_urls = "other_ema_urls"
 ema_number_id = "ema_number_id"
 ema_od_number_id = "ema_od_number_id"
+status_type = "status_type"  # status of medicine: active, withdrawn or refused
+
+file_date_pdf_link = "pdf_link"
+file_date_pdf_date = "pdf_date"
+file_date_pdf_scrape_date = "pdf_scrape_date"
+

--- a/scraping/web_scraper/download.py
+++ b/scraping/web_scraper/download.py
@@ -29,16 +29,16 @@ def get_date_from_url(url: str) -> dict[str, str]:
     Returns:
         (dict[str, str]): A tuple containing the url, the date of the url and the datetime of the scrape
     """
-    file_date = datetime.now()
+    file_date = date.today()
     url_date = re.findall(r"\d{8}", url)
     if url_date:
         url_date = url_date[0]
         if url_date[:2] == "19" or url_date[:2] == "20":
-            file_date = datetime.strptime(url_date, '%Y%m%d')
+            file_date = (datetime.strptime(url_date, '%Y%m%d')).date()
     return {
-        "pdf_link": url,
-        "pdf_date": str(file_date),
-        "pdf_scrape_date": str(datetime.now())
+        attr.file_date_pdf_link: url,
+        attr.file_date_pdf_date: str(file_date),
+        attr.file_date_pdf_scrape_date: str(date.today())
     }
 
 
@@ -160,7 +160,7 @@ def download_pdfs_ec(medicine_identifier: str, pdf_type: str, pdf_urls: list[str
     if pdf_type == "anx":
         overwrite_dict: json = {
             medicine_identifier: {
-                "overwrite_ec_files": "False"
+                attr.overwrite_ec_files: "False"
             }
         }
         urls_dict.add_to_dict(overwrite_dict)
@@ -227,7 +227,7 @@ def download_medicine_files(medicine_identifier: str, url_dict: dict[str, list[s
         if key not in url_dict.keys():
             log.error(f"Key {key} not in keys of url_dict with identifier {medicine_identifier}. url_dict: {url_dict}")
         download_pdfs_ec(medicine_identifier, filetype, url_dict[key], attr_dict, target_path, urls_json,
-                         url_dict.get("overwrite_ec_files", "True") == "True")
+                         url_dict.get(attr.overwrite_ec_files, "True") == "True")
 
     download_list_ema = [('epar', attr.epar_url), ('omar', attr.omar_url), ("odwar", attr.odwar_url)]
     for (filetype, key) in download_list_ema:

--- a/scraping/web_scraper/ema_scraper.py
+++ b/scraping/web_scraper/ema_scraper.py
@@ -1,6 +1,6 @@
 import logging
 import multiprocessing
-from datetime import datetime
+from datetime import datetime, date
 from itertools import repeat
 
 import bs4
@@ -59,9 +59,9 @@ def scrape_medicine_page(url: str, html_active: requests.Response) -> dict[str, 
     # Final dict that will be returned.
     # Filled with values here, last attribute "other_ema_urls" filled after
     result_dict: dict[str, str | list[tuple]] = {
-        "odwar_url": find_priority_link(med_type.odwar_priority_list, url_list_init),
-        "omar_url": find_priority_link(med_type.omar_priority_list, url_list_init),
-        "epar_url": find_priority_link(med_type.epar_priority_list, url_list_init)
+        attr.odwar_url: find_priority_link(med_type.odwar_priority_list, url_list_init),
+        attr.omar_url: find_priority_link(med_type.omar_priority_list, url_list_init),
+        attr.epar_url: find_priority_link(med_type.epar_priority_list, url_list_init)
     }
 
     # All links that are not saved into the dictionary already, as well as the links under assessment history
@@ -212,22 +212,22 @@ def get_annex10_data(url: str, annex_dict: dict[str, dict[str, str]]) -> dict[st
         # the dictionary needs to be updated with the new link. Also, new entries must always be added
         year_s = str(year)
         if year_s in annex_dict.keys():
-            last_updated_local: datetime = datetime.strptime(annex_dict[year_s]["last_updated"], '%d/%m/%Y')
-            last_updated_site: datetime = find_last_updated_date_annex10(specific_soup.find_all('small')[1].get_text())
+            last_updated_local: datetime.date = datetime.strptime(annex_dict[year_s]["last_updated"], '%d/%m/%Y').date()
+            last_updated_site: datetime.date = find_last_updated_date_annex10(specific_soup.find_all('small')[1].get_text())
 
             # ignore files that have not changed since last time downloading
             if last_updated_local > last_updated_site:
                 continue
 
         annex_dict[year_s] = {
-            "last_updated": datetime.strftime(datetime.now(), '%d/%m/%Y'),
-            "annex10_url": excel_link
+            "last_updated": date.today().strftime('%d/%m/%Y'),
+            attr.annex10_url: excel_link
         }
 
     return annex_dict
 
 
-def find_last_updated_date(html_active: requests.Response) -> datetime:
+def find_last_updated_date(html_active: requests.Response) -> datetime.date:
     """
     Finds the date when a medicine page was last updated
 
@@ -236,16 +236,16 @@ def find_last_updated_date(html_active: requests.Response) -> datetime:
             html object that contains raw html for a webpage for a medicine on the EMA website
 
     Returns:
-        datetime: When the medicine page on the EMA website was last updated
+        datetime.date: When the medicine page on the EMA website was last updated
     """
     soup = bs4.BeautifulSoup(html_active.text, html_parser_str)
     last_updated_element = soup.find("meta", property="og:updated_time")["content"]
     last_updated_text = last_updated_element.split('T')[0]
     last_updated_datetime = datetime.strptime(last_updated_text, '%Y-%m-%d')
-    return last_updated_datetime
+    return last_updated_datetime.date()
 
 
-def find_last_updated_date_annex10(text: str) -> datetime:
+def find_last_updated_date_annex10(text: str) -> date:
     """
     Converts a piece of text with information when an excel-sheet was last updated to a datetime object
 
@@ -265,7 +265,7 @@ def find_last_updated_date_annex10(text: str) -> datetime:
     else:
         updated_date: str = new_text[2]
 
-    return datetime.strptime(updated_date, '%d/%m/%Y')
+    return (datetime.strptime(updated_date, '%d/%m/%Y')).date()
 
 
 @utils.exception_retry(logging_instance=log)
@@ -287,7 +287,7 @@ def get_epar_excel_url(url: str, ema_excel_json_helper: json_helper.JsonHelper) 
     soup = bs4.BeautifulSoup(html_active.text, html_parser_str)
 
     # Gets the last updated date from the page
-    last_updated_date: datetime = find_last_updated_date(html_active)
+    last_updated_date: datetime.date = find_last_updated_date(html_active)
 
     # Gets the link to the EMA Excel file
     excel_url_part: str = soup.find("a", string="Download table of all EPARs for human and veterinary "
@@ -297,7 +297,7 @@ def get_epar_excel_url(url: str, ema_excel_json_helper: json_helper.JsonHelper) 
 
     # Checks whether the Excel file needs to be downloaded again.
     if ema_excel_dict.get("last_scrape_date", "") != "":
-        last_scrape_date: datetime = datetime.strptime(ema_excel_dict.get("last_scrape_date"), "%d/%m/%Y")
+        last_scrape_date: datetime.date = (datetime.strptime(ema_excel_dict.get("last_scrape_date"), "%d/%m/%Y")).date()
         if last_updated_date > last_scrape_date:
             download_excel: bool = True
         else:
@@ -308,7 +308,7 @@ def get_epar_excel_url(url: str, ema_excel_json_helper: json_helper.JsonHelper) 
     # Saves the (new) url and the scrape date to the dictionary
     ema_excel_json_helper.overwrite_dict({
         "url": excel_url,
-        "last_scrape_date": datetime.strftime(datetime.now(), "%d/%m/%Y")
+        "last_scrape_date": date.today().strftime("%d/%m/%Y")
     })
     ema_excel_json_helper.save_dict()
 

--- a/scraping/web_scraper/save_webdata.py
+++ b/scraping/web_scraper/save_webdata.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import date
 from pathlib import Path
 
 import scraping.utilities.definitions.attributes as attr
@@ -33,8 +33,8 @@ def set_active_refused_webdata(eu_n: str, medicine_url: str, dec_list: list[str]
     # Sets parameter values for refused medicines that need to be saved
     else:
         # Checks if the medicine is a human or orphan one, and based on that picks the right EMA number
-        ema_number_str: str = "ema_number"
-        ema_od_number_str: str = "ema_od_number"
+        ema_number_str: str = attr.ema_number
+        ema_od_number_str: str = attr.ema_od_number
         # Based on whether there is an EMA number, sets the medicine identifier to the EMA number or the product name
         if ema_number_str in attributes_dict.keys():
             medicine_identifier: str = "REFUSED-" + attributes_dict[ema_number_str].replace('/', '-')
@@ -67,14 +67,14 @@ def save_webdata_and_urls(medicine_identifier: str, medicine_url: str, dec_list:
         target_path (str): Directory where the json needs to be stored.
     """
     # TODO: Common name structure?
-    url_json: dict[str, list[str] | str, str] = {
+    url_json = {
         medicine_identifier: {
             attr.ec_url: medicine_url,
             attr.aut_url: dec_list,
             attr.smpc_url: anx_list,
             attr.ema_url: ema_list,
-            attr.scrape_date_web: datetime.strftime(datetime.today(), '%d/%m/%Y'),
-            "overwrite_ec_files": "True"
+            attr.scrape_date_web: date.today().strftime('%d/%m/%Y'),
+            attr.overwrite_ec_files: "True"
         }
     }
 
@@ -84,5 +84,5 @@ def save_webdata_and_urls(medicine_identifier: str, medicine_url: str, dec_list:
     # otherwise it just adds the json file to the existing directory
     Path(f"{target_path}").mkdir(exist_ok=True)
     with open(f"{target_path}/{medicine_identifier}_webdata.json", 'w') as f:
-        attributes_dict["scrape_date_web"] = datetime.strftime(datetime.today(), '%d/%m/%Y')
+        attributes_dict[attr.scrape_date_web] = date.today().strftime('%d/%m/%Y')
         json.dump(attributes_dict, f, indent=4)

--- a/scraping/web_scraper/url_scraper.py
+++ b/scraping/web_scraper/url_scraper.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, date
 
 import scraping.utilities.definitions.attributes as attr
 from scraping.utilities.web import web_utils as utils, json_helper
@@ -62,7 +62,7 @@ def get_urls_ec(medicine_url: str, eu_n: str, medicine_type: MedicineType, data_
 
     # Retrieves the date the EC medicine page was last updated
     html_active = utils.get_html_object(medicine_url)
-    medicine_last_updated_date = ec_scraper.get_last_updated_date(html_active)
+    medicine_last_updated_date: datetime.date = ec_scraper.get_last_updated_date(html_active)
 
     # Checks whether attributes and files need to be scraped from the EC web page
     if not check_scrape_page(eu_n, medicine_last_updated_date, "ec", url_file):
@@ -97,7 +97,7 @@ def get_urls_ema(eu_n: str, url: str, url_file: json_helper.JsonHelper):
     """
     # Retrieves the date the EMA medicine page was last updated
     html_active = utils.get_html_object(url)
-    medicine_last_updated_date: datetime = ema_scraper.find_last_updated_date(html_active)
+    medicine_last_updated_date: datetime.date = ema_scraper.find_last_updated_date(html_active)
 
     # Checks whether attributes and files need to be scraped from the EMA web page
     if not check_scrape_page(eu_n, medicine_last_updated_date, "ema", url_file):
@@ -112,7 +112,7 @@ def get_urls_ema(eu_n: str, url: str, url_file: json_helper.JsonHelper):
     url_file.add_to_dict(pdf_url)
 
 
-def check_scrape_page(eu_n: str, medicine_last_updated: datetime, last_scraped_type: str,
+def check_scrape_page(eu_n: str, medicine_last_updated: datetime.date, last_scraped_type: str,
                       url_file: json_helper.JsonHelper) -> bool:
     """
     Checks whether the medicine page (either EC or EMA) has been updated since last scrape cycle, or that the page has

--- a/tests/web_scraper_tests/test_download.py
+++ b/tests/web_scraper_tests/test_download.py
@@ -1,6 +1,6 @@
 from os import path, remove
 import os
-from datetime import datetime
+from datetime import datetime, date
 import regex as re
 from unittest import TestCase
 from scraping.web_scraper import download
@@ -28,16 +28,16 @@ class TestDownload(TestCase):
             url: url of a file that needs to be tested
         """
         filedates_dict = download.get_date_from_url(url)
-        url_out = filedates_dict["pdf_link"]
-        date1 = filedates_dict["pdf_date"]
-        date1 = datetime.strptime(date1.split()[0], '%Y-%m-%d')
-        date2 = filedates_dict["pdf_scrape_date"]
-        date2 = datetime.strptime(date2.split()[0], '%Y-%m-%d')
+        url_out = filedates_dict[attr.file_date_pdf_link]
+        date1 = filedates_dict[attr.file_date_pdf_date]
+        date1 = datetime.strptime(date1.split()[0], '%Y-%m-%d').date()
+        date2 = filedates_dict[attr.file_date_pdf_scrape_date]
+        date2 = datetime.strptime(date2.split()[0], '%Y-%m-%d').date()
 
         self.assertTrue(url == url_out)
         if len((re.findall(r"\d{8}", url))) > 0:
-            self.assertTrue(date1.date() != datetime.now().date())
-        self.assertTrue(date2.date() == datetime.now().date())
+            self.assertTrue(date1 != date.today())
+        self.assertTrue(date2 == date.today())
 
     @parameterized.expand([["https://ec.europa.eu/health/documents/community-register/2022/20220324154987"
                             "/dec_154987_en.pdf",
@@ -115,7 +115,7 @@ class TestDownload(TestCase):
                                          "-epar-public-assessment-report_en.pdf",
                              attr.omar_url: "",
                              attr.odwar_url: "",
-                             "other_ema_urls": []}
+                             attr.other_ema_urls: []}
                             ]])
     def test_download_medicine_files(self, eu_n, url_dict):
         """

--- a/tests/web_scraper_tests/test_ec_scraper.py
+++ b/tests/web_scraper_tests/test_ec_scraper.py
@@ -123,7 +123,7 @@ class TestEcScraper(unittest.TestCase):
     @parameterized.expand([
         [
             "h477",
-            "2008-10-07 00:00:00",
+            "2008-10-07",
             "exceptional",
             "",
             "",

--- a/tests/web_scraper_tests/test_ema_scraper.py
+++ b/tests/web_scraper_tests/test_ema_scraper.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, date
 from scraping.web_scraper import ema_scraper as em
 import scraping.utilities.web.web_utils as utils
 from parameterized import parameterized
@@ -99,7 +99,7 @@ class TestEMAScraper(unittest.TestCase):
 
     @parameterized.expand([
         ["https://www.ema.europa.eu/en/medicines/human/EPAR/alymsys",
-         datetime.strptime("15/12/2022", '%d/%m/%Y')]
+         datetime.strptime("15/12/2022", '%d/%m/%Y').date()]
     ])
     def test_find_last_updated_date(self, url, exp_output):
         """

--- a/tests/web_scraper_tests/test_web_scraper.py
+++ b/tests/web_scraper_tests/test_web_scraper.py
@@ -171,7 +171,7 @@ class TestWebScraper(TestCase):
         # check if all files from urls.json are downloaded:
         with open(json_path / "urls.json") as f:
             url_dict = (json.load(f))[self.eu_n]
-        filecount = len(url_dict["aut_url"]) + len(url_dict[attr.smpc_url])
+        filecount = len(url_dict[attr.aut_url]) + len(url_dict[attr.smpc_url])
 
         if url_dict[attr.epar_url]:
             filecount += 1


### PR DESCRIPTION
Overal definitions gecheckt, en overal in web van datetime naar date.

Paar dingen waarvan ik niet weet of die ook in attributes.py moeten:
ema_scraper.py:
- 223: last_updated -> deze ook in attributes.py?
- 300: last_scrape_date -> ?
- 310: url -> ?

In deze branch zijn dus niet de values aangepast, dat gebeurt in de 390 feature branch
Ik heb development al in deze branch gemerged en daarin de merge conflicts gefixt in principe